### PR TITLE
Remove spurious "typename"s in typedefs in HLLib.h

### DIFF
--- a/lib/HLLib.h
+++ b/lib/HLLib.h
@@ -2031,11 +2031,11 @@ namespace HLLib
 		class CSGASpecializedDirectory : public ISGADirectory
 		{
 		public:
-			typedef typename TSGAHeader SGAHeader;
-			typedef typename TSGADirectoryHeader SGADirectoryHeader;
-			typedef typename TSGASection SGASection;
-			typedef typename TSGAFolder SGAFolder;
-			typedef typename TSGAFile SGAFile;
+			typedef TSGAHeader SGAHeader;
+			typedef TSGADirectoryHeader SGADirectoryHeader;
+			typedef TSGASection SGASection;
+			typedef TSGAFolder SGAFolder;
+			typedef TSGAFile SGAFile;
 
 			CSGASpecializedDirectory(CSGAFile& File);
 
@@ -2060,10 +2060,10 @@ namespace HLLib
 		class CSGASpecializedDirectory<TSGAHeader, TSGADirectoryHeader, TSGASection, TSGAFolder, SGAFile4> : public ISGADirectory
 		{
 		public:
-			typedef typename TSGAHeader SGAHeader;
-			typedef typename TSGADirectoryHeader SGADirectoryHeader;
-			typedef typename TSGASection SGASection;
-			typedef typename TSGAFolder SGAFolder;
+			typedef TSGAHeader SGAHeader;
+			typedef TSGADirectoryHeader SGADirectoryHeader;
+			typedef TSGASection SGASection;
+			typedef TSGAFolder SGAFolder;
 			typedef CSGAFile::SGAFile4 SGAFile;
 
 			CSGASpecializedDirectory(CSGAFile& File);
@@ -2089,10 +2089,10 @@ namespace HLLib
 		class CSGASpecializedDirectory<TSGAHeader, TSGADirectoryHeader, TSGASection, TSGAFolder, SGAFile6> : public ISGADirectory
 		{
 		public:
-			typedef typename TSGAHeader SGAHeader;
-			typedef typename TSGADirectoryHeader SGADirectoryHeader;
-			typedef typename TSGASection SGASection;
-			typedef typename TSGAFolder SGAFolder;
+			typedef TSGAHeader SGAHeader;
+			typedef TSGADirectoryHeader SGADirectoryHeader;
+			typedef TSGASection SGASection;
+			typedef TSGAFolder SGAFolder;
 			typedef CSGAFile::SGAFile6 SGAFile;
 
 			CSGASpecializedDirectory(CSGAFile& File);


### PR DESCRIPTION
Commit 423adba1daf8094b643e74cd4d26725057277c32 did this for SGAFile.h but didn't fix it for HLLib.h itself, causing compile errors for programs using the library.