### PR TITLE
Fix for recent Dota 2 VPK files

### DIFF
--- a/HLLib/VPKFile.cpp
+++ b/HLLib/VPKFile.cpp
@@ -115,7 +115,7 @@ hlBool CVPKFile::MapDataStructures()
 		}
 	}
 
-	while(hlTrue)
+	while(lpViewData != lpViewDirectoryDataEnd)
 	{
 		const hlChar *lpExtension;
 		if(!this->MapString(lpViewData, lpViewDirectoryDataEnd, lpExtension))


### PR DESCRIPTION
Valve recently updated Dota 2 with VPK files that don't work with HLLib. They're missing a null character at the end of the list of directory entries. This fixes that by checking if there are any bytes left before starting another loop to get the entry.

I can't find the canonical version of HLLib (Nem's site seems out of date and there's no reply using the contact details).